### PR TITLE
support streaming on events and logs endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Set timeout to one day on events and logs entrypoints to allow streaming
+- Increase maximum connection count to 512
+
+### Added
+- Separate dockerfile for debug-to-stdout variant
+
 ## [1.0.0] - 2017-11-13
 Initial release based on haproxy 1.7

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM haproxy:1.7-alpine
-COPY haproxy.cfg url-whitelist.lst /usr/local/etc/haproxy/
+COPY haproxy.cfg url-whitelist.lst long-requests-whitelist.lst /usr/local/etc/haproxy/
 
 HEALTHCHECK --interval=5m --timeout=2s \
   CMD ls /safe-socket/docker.sock

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -4,3 +4,6 @@ COPY haproxy.cfg url-whitelist.lst /usr/local/etc/haproxy/
 HEALTHCHECK --interval=5m --timeout=2s \
   CMD ls /safe-socket/docker.sock
 
+## Run with debugging to stdout
+CMD ["haproxy", "-d", "-db", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+ENTRYPOINT []

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,5 +1,5 @@
 FROM haproxy:1.7-alpine
-COPY haproxy.cfg url-whitelist.lst /usr/local/etc/haproxy/
+COPY haproxy.cfg url-whitelist.lst long-requests-whitelist.lst /usr/local/etc/haproxy/
 
 HEALTHCHECK --interval=5m --timeout=2s \
   CMD ls /safe-socket/docker.sock

--- a/docker/haproxy.cfg
+++ b/docker/haproxy.cfg
@@ -1,14 +1,31 @@
 global
-    maxconn 64
+    maxconn 512
 defaults
     mode http
     timeout connect 500ms
-    timeout client 5000ms
+    timeout client-fin 5000ms
+    timeout client 1d
     timeout server 5000ms
+
 frontend http-in
     bind /safe-socket/docker.sock mode 666
+    default_backend docker-shortqueries
+
     acl valid-url path_reg -f /usr/local/etc/haproxy/url-whitelist.lst
     http-request deny unless METH_GET valid-url
-    default_backend docker-socket-backend
-backend docker-socket-backend
+
+    acl long-requests path_reg -f /usr/local/etc/haproxy/long-requests-whitelist.lst
+    use_backend docker-longqueries if long-requests
+
+# This is the default backend for most queries, with the default
+# server timeout
+backend docker-shortqueries
     server socket /var/run/docker.sock
+
+# This backend has a one day timeout on the server side to allow
+# for the streaming `events` and `log` endpoints
+# Please note that the stream can still EOF if empty for a
+# day, so clients should reconnect on EOF
+backend docker-longqueries
+    server socket /var/run/docker.sock
+    timeout server 1d

--- a/docker/long-requests-whitelist.lst
+++ b/docker/long-requests-whitelist.lst
@@ -1,0 +1,2 @@
+^\/v[0-9.]+\/containers\/[0-9a-z]+\/logs$
+^\/v[0-9.]+\/events$

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -5,7 +5,9 @@ volumes:
 
 services:
   dockerproxy:
-    build: ./../docker
+    build:
+      context: ./../docker
+      dockerfile: Dockerfile
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - safe-socket:/safe-socket:rw


### PR DESCRIPTION
### Changed
- Set timeout to one day on events and logs entrypoints to allow streaming
- Increase maximum connection count to 512
- Updated integration tests

### Added
- Separate dockerfile for debug-to-stdout variant