### PR TITLE
Improve health check and debugability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0] - 2018-12-21
+### Changed
+- Add a curl based health check to validate that the socket it working
+- Add haproxy.sock + socat to have a way to get statistics
+
 ## [1.1.0] - 2017-11-28
 ### Changed
 - Set timeout to one day on events and logs entrypoints to allow streaming

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The [authorization subsystem](https://docs.docker.com/engine/extend/plugins_auth
 - it requires SSL client certificate authentication, which is currently not supported on the unix socket, potentially breaking orchestrators and third party software assuming access to `/var/run/docker.sock`
 - it is not self-contained in the Docker engine, but requires the sysadmin to install and configure a third-party software
 - if no certificate chain is already setup, creating one for that use case is a big hurdle
- 
+
 This is why this container aims at providing a simpler solution.
 
 ## How?
@@ -27,3 +27,7 @@ The Docker management API is a standard [HTTP REST API](https://docs.docker.com/
 - passes URLs through a [whitelist](docker/url-whitelist.lst) to forbid access to endpoints that might be exploited to escalade access (attach via a websocket) or enable DoS attacks (disk/network intensive read-only operations)
 
 The remaining endpoints are deemed safe for use and are accessible on the safe socket. This socket can then be exposed to monitoring software.
+
+## Troubleshooting
+
+Inside the docker-filter container you should be able to access haproxy.sock, see https://www.datadoghq.com/blog/how-to-collect-haproxy-metrics/#socket-communication to know more about how to use it to troubleshoot haproxy.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM haproxy:1.7-alpine
+
+RUN apk add --no-cache curl socat
+
 COPY haproxy.cfg url-whitelist.lst long-requests-whitelist.lst /usr/local/etc/haproxy/
 
 HEALTHCHECK --interval=5m --timeout=2s \
-  CMD ls /safe-socket/docker.sock
+  CMD curl --fail -v --no-buffer -XGET --unix-socket /safe-socket/docker.sock  http://localhost/_ping
 

--- a/docker/haproxy.cfg
+++ b/docker/haproxy.cfg
@@ -32,12 +32,8 @@ backend docker-longqueries
 
 
 # Stats, for debuging
+# See https://www.datadoghq.com/blog/how-to-collect-haproxy-metrics/#socket-communication
 global
     stats socket /var/run/haproxy.sock mode 600 level admin
     stats timeout 2m
 
-listen stats
-  bind :9000
-  mode http
-  stats enable
-  stats uri /

--- a/docker/haproxy.cfg
+++ b/docker/haproxy.cfg
@@ -29,3 +29,15 @@ backend docker-shortqueries
 backend docker-longqueries
     server socket /var/run/docker.sock
     timeout server 1d
+
+
+# Stats, for debuging
+global
+    stats socket /var/run/haproxy.sock mode 600 level admin
+    stats timeout 2m
+
+listen stats
+  bind :9000
+  mode http
+  stats enable
+  stats uri /


### PR DESCRIPTION
We suspect that our setup is leaking connections and that is
forcing us to restart haproxy regularly, but because the container
usually has no network it makes it super hard to debug in prod.

This PR add the most basic tools we would need to debug issues.

It also forces a restart when the safe docker is not able to forward
a _ping request.

See https://trello.com/c/tU7zkmn7/86-docker-filter-breaking-down