### PR TITLE
Increase HAProxy maxconn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-01-02
+### Changed
+- Decrease longqueries server timeout to 5 min (from 1d)
+
 ## [1.2.0] - 2018-12-21
 ### Changed
 - Add a curl based health check to validate that the socket it working

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Datadog, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docker/haproxy.cfg
+++ b/docker/haproxy.cfg
@@ -28,7 +28,7 @@ backend docker-shortqueries
 # day, so clients should reconnect on EOF
 backend docker-longqueries
     server socket /var/run/docker.sock
-    timeout server 1d
+    timeout server 5m
 
 
 # Stats, for debuging
@@ -36,4 +36,3 @@ backend docker-longqueries
 global
     stats socket /var/run/haproxy.sock mode 600 level admin
     stats timeout 2m
-


### PR DESCRIPTION
We recently made a change in the agent to retry tailing logs on a container if no logs has been received for 30 sec (to handle the case of the log rotation when docker `max-file` option is set to 1). We ran into an issue when docker-filter reached 512 open connections. The docker monitoring broke for those nodes (that were not logging often).

We discovered that docker-filter was keeping connections open (for an unknown reason). I replicated the problem on my machine with docker filter and the agent running on the docker-filter socket. The connections remain open even after stopping the agent. I doesn't seem to happen when talking directly to the docker socket

The connections timeout after a day and they are 2880 30sec intervals in a day. For a quick fix, I propose to increase the number of connection to 4096 so we don't run into this issue again. 

It would be interesting to know why that happens though